### PR TITLE
capitalization matters (for tags)

### DIFF
--- a/blog/_posts/2017/2017-10-03-ausschreibung-codeforgermany.md
+++ b/blog/_posts/2017/2017-10-03-ausschreibung-codeforgermany.md
@@ -10,7 +10,7 @@ tags:
  - codeforgermany
  - Ausschreibung
  - community
- - jobs
+ - Jobs
 title: "Community Organizer für Code for Germany m/w (50%)"
 ---
 


### PR DESCRIPTION
capitalization seems to matter for tags (in jekyll). (btw: that causes the problem that you are getting the same (incomplete) result by selecting different case sensitive tags in the tag cloud.) so consistency might be important for using tags.

https://github.com/pattex/jekyll-tagging#tags says "lowercase tags". i changed it to the capital case because all the other pages are tagged so. (and the filter (by lower case) will work temporarily (again). so you can find all results with upper and lower first letter.)